### PR TITLE
Add ability to show tickets that are completed but not part of any version

### DIFF
--- a/JustReleaseNotes/sourcers/GitRepo.py
+++ b/JustReleaseNotes/sourcers/GitRepo.py
@@ -146,5 +146,13 @@ class GitRepo:
                 self.versionsByGitHash[hexsha] = version     
 
             self.gitHistoryByVersion[version] = self.__getParentsListForVersion(hexsha,version, [])
-            
+
+        self.__addHeadIfNotPresent()
         self.__optimizeHistoryByVersion()
+
+    def __addHeadIfNotPresent(self):
+        hexsha = str(self.__repoX.heads[self.__branch].commit)
+        if hexsha not in self.versionsByGitHash:
+            version = str(sys.maxsize)
+            self.versionsByGitHash[hexsha] = version
+            self.gitHistoryByVersion[version] = self.__getParentsListForVersion(hexsha, version, [])

--- a/JustReleaseNotes/writers/BaseWriter.py
+++ b/JustReleaseNotes/writers/BaseWriter.py
@@ -1,0 +1,9 @@
+import re
+import sys
+
+class BaseWriter:
+
+    def convertVersion(self, version):
+        if (version == str(sys.maxsize)):
+            version = "Upcoming developments"
+        return version

--- a/JustReleaseNotes/writers/HtmlWriter.py
+++ b/JustReleaseNotes/writers/HtmlWriter.py
@@ -1,6 +1,7 @@
 import re
+from JustReleaseNotes.writers import BaseWriter
 
-class HtmlWriter:
+class HtmlWriter(BaseWriter.BaseWriter):
 
     def __init__(self, ticketProvider):
         self.__ticketProvider = ticketProvider
@@ -9,6 +10,8 @@ class HtmlWriter:
         return ".html"
 
     def printVersionBlock(self, deps, version, date, tickets):
+        version = self.convertVersion(version)
+
         data = [
             "<div style=\"width:100%; border: 0px\">",
             "<a name=\"" + version + "\"></a>"]

--- a/JustReleaseNotes/writers/MarkdownWriter.py
+++ b/JustReleaseNotes/writers/MarkdownWriter.py
@@ -1,6 +1,7 @@
 import re
+from JustReleaseNotes.writers import BaseWriter
 
-class MarkdownWriter:
+class MarkdownWriter(BaseWriter.BaseWriter):
 
     def __init__(self, ticketProvider):
         self.__ticketProvider = ticketProvider
@@ -9,6 +10,8 @@ class MarkdownWriter:
         return ".md"
 
     def printVersionBlock(self, deps, version, date, tickets):
+        version = self.convertVersion(version)
+
         data = ["## {0} ##".format(version)]
         if date != 'N/A':
             data.append(date)

--- a/README.rst
+++ b/README.rst
@@ -41,14 +41,14 @@ Configuration file is in flux. For now it is a json looking something like this:
 
         "packages" : {
             <package name> : {
-                "Issues" : {
+                "Issues" : [{
                     "Provider" : <issues provider>,
                     "HtmlUrl" : ...,
                     "Authorization" : ...,
                     "Url" : ...,
                     "WebImagesPath" : ...
                     "TicketRegex" : ...
-                },
+                }],
                 "Releases" : {
                     "Provider" : <releases provider>,
                     "Repository" : ...,
@@ -60,8 +60,17 @@ Configuration file is in flux. For now it is a json looking something like this:
                     "RepositoryUrl" : ...
                     "Remote" : ...
                     "Branch" : ...
+                    "VersionTagRegex" : "^([0-9]+\\.[0-9]+\\.[0-9]+)$"
                 },
-                "ReleaseNotesWriter" : <notes writer>
+                "ReleaseNotesWriter" : [
+                    {
+                        "Provider" : "MarkdownWriter",
+                        "PathToSave" : "index.md"
+                    },
+                    {
+                        "Provider" : "HtmlWriter",
+                        "PathToSave" : "wwwroot/release_notes.html"
+                    }]
             }
         }
     }

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ except:
     long_description = description
 
 setup(name='JustReleaseNotes',
-      version='0.1.2',
+      version='0.1.3',
       description='Release notes generator package',
       long_description=long_description,
       url='https://github.com/Cimpress-MCP/JustReleaseNotes',

--- a/tests/writers/BaseWriter_Test.py
+++ b/tests/writers/BaseWriter_Test.py
@@ -1,0 +1,11 @@
+import unittest
+from JustReleaseNotes.writers import BaseWriter
+import sys
+
+class BaseWriter_Test(unittest.TestCase):
+    def test_convertVersionTranslatesMaxValue(self):
+        writer = BaseWriter.BaseWriter()
+        self.assertEqual("Upcoming developments", writer.convertVersion(str(sys.maxsize)))
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Adding head as additional label (version maxsize). That way if there is no artificter filtering (means we want to see all versions and all progress - not just the promoted one) the "Upcoming developments" section will show up listing tickets that are in the configured branch, but are not between any two tags.
