### PR TITLE
#33 Add 'OldestCommitToProcess' setting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ GitReleaseNotes/output/
 *.json
 JustReleaseNotes.egg-info/
 dist/
+build/

--- a/JustReleaseNotes/sourcers/GitRepo.py
+++ b/JustReleaseNotes/sourcers/GitRepo.py
@@ -25,6 +25,10 @@ class GitRepo:
         self.__directory = conf["Directory"]
         self.__repoX = ""
         self.__versionTagRegex = "^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$"
+        self.__excludeCommitsWithMessageMatchingRegex = None
+
+        if "ExcludeCommitsWithMessageMatchingRegex" in conf:
+            self.__excludeCommitsWithMessageMatchingRegex = conf["ExcludeCommitsWithMessageMatchingRegex"]
 
         if "VersionTagRegex" in conf:
             self.__versionTagRegex = conf["VersionTagRegex"]
@@ -91,6 +95,11 @@ class GitRepo:
         self.__processCommit(self.__repoX.commit(commitHash))
 
     def __processCommit(self, commit):
+        if self.__excludeCommitsWithMessageMatchingRegex is not None:
+            p = re.compile(self.__excludeCommitsWithMessageMatchingRegex)
+            if p.match(commit.message):
+                return
+
         self.gitCommitMessagesByHash[commit.hexsha] = commit.summary + commit.message
         self.gitCommitsList.append(commit.hexsha)
         self.gitDatesByHash[commit.hexsha] = commit.authored_date

--- a/JustReleaseNotes/sourcers/GitRepo.py
+++ b/JustReleaseNotes/sourcers/GitRepo.py
@@ -74,9 +74,9 @@ class GitRepo:
         self.commitParents[commit.hexsha] = []
         for p in commit.parents:
             self.commitParents[commit.hexsha] = self.commitParents[commit.hexsha] + [p.hexsha]
-            self.setParents(p)
-            
-    def __getParentsListForVersion(self, hash, version, resultsSoFar):
+            self.__processCommit(p)
+
+    def __getParentsListForVersion(self, hash, resultsSoFar):
         if hash in resultsSoFar:
             return []
         if hash not in self.commitParents:
@@ -84,7 +84,7 @@ class GitRepo:
         results = [hash]
         for p in self.commitParents[hash]:
             if p not in self.versionsByGitHash:
-                results = results + self.__getParentsListForVersion(p, version, resultsSoFar + results)
+                results = results + self.__getParentsListForVersion(p, resultsSoFar + results)
         return results
 
     def processCommit(self, commitHash):
@@ -155,7 +155,7 @@ class GitRepo:
             else:
                 self.versionsByGitHash[hexsha] = version     
 
-            self.gitHistoryByVersion[version] = self.__getParentsListForVersion(hexsha,version, [])
+            self.gitHistoryByVersion[version] = self.__getParentsListForVersion(hexsha, [])
 
         self.__addHeadIfNotPresent()
         self.__optimizeHistoryByVersion()
@@ -165,4 +165,4 @@ class GitRepo:
         if hexsha not in self.versionsByGitHash:
             version = str(sys.maxsize)
             self.versionsByGitHash[hexsha] = version
-            self.gitHistoryByVersion[version] = self.__getParentsListForVersion(hexsha, version, [])
+            self.gitHistoryByVersion[version] = self.__getParentsListForVersion(hexsha, [])

--- a/JustReleaseNotes/sourcers/GitRepo.py
+++ b/JustReleaseNotes/sourcers/GitRepo.py
@@ -7,6 +7,7 @@ class GitRepo:
     __packageName = ""
     __remote = "origin"
     __branch = "master"
+    __recursionLimit = 16384
     
     gitCommitsList = []
     gitCommitMessagesByHash = {}
@@ -26,6 +27,13 @@ class GitRepo:
         self.__repoX = ""
         self.__versionTagRegex = "^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$"
         self.__excludeCommitsWithMessageMatchingRegex = None
+
+        # TODO: Remove as part of #48 Refactor recursive calls in sourcers
+        # the default stack size for recursive calls in Python is set to 1000, which can easily overflow with bigger repositories
+        if (sys.getrecursionlimit() < self.__recursionLimit):
+            print("Increasing the stack size for recursive calls from {0} to {1}"
+                  .format(sys.getrecursionlimit(), self.__recursionLimit))
+            sys.setrecursionlimit(self.__recursionLimit)
 
         if "ExcludeCommitsWithMessageMatchingRegex" in conf:
             self.__excludeCommitsWithMessageMatchingRegex = conf["ExcludeCommitsWithMessageMatchingRegex"]

--- a/JustReleaseNotes/writers/HtmlWriter.py
+++ b/JustReleaseNotes/writers/HtmlWriter.py
@@ -1,4 +1,4 @@
-import re
+import re, sys
 from JustReleaseNotes.writers import BaseWriter
 
 class HtmlWriter(BaseWriter.BaseWriter):
@@ -60,12 +60,22 @@ class HtmlWriter(BaseWriter.BaseWriter):
                         imgHtml += imgFormat.format("Issue Type", ticketInfo["issue_type_icon"])
                     if "priority_icon" in ticketInfo:
                         imgHtml += imgFormat.format("Priority", ticketInfo["priority_icon"])
+
+                    reporter = ""
+                    if sys.version_info < (3,):
+                        reporter = ticketInfo["reporter"].encode('utf-8')
+                    else:
+                        reporter = bytearray(ticketInfo["reporter"], 'utf-8').decode('utf-8')
+
                     data.append('<li style="font-size:14px">{0}<a href="{3}">{1}</a> {2}, <i>reported by</i> <b>{4}</b></li>'.format(
-                        imgHtml, ticketInfo["ticket"], title , ticketInfo["html_url"], ticketInfo["reporter"]))
+                        imgHtml, ticketInfo["ticket"], title , ticketInfo["html_url"], reporter))
 
         if appendStabilityImprovements:
             data.append("<li style=\"font-size:14px\">Stability improvements</li>")
 
         data += ["</ul>", "</div>", ""]
 
-        return '\n'.join(data)
+        if sys.version_info < (3,):
+            return '\n'.join(x.decode('utf-8') for x in data)
+        else:
+            return '\n'.join(x for x in data)

--- a/README.rst
+++ b/README.rst
@@ -55,7 +55,7 @@ Configuration file is in flux. For now it is a json looking something like this:
                     "HtmlUrl" : ...,
                     "Authorization" : ...,
                     "Url" : ...,
-                    "WebImagesPath" : ...
+                    "WebImagesPath" : ...,
                     "TicketRegex" : ...
                 }],
                 "Releases" : {
@@ -65,14 +65,16 @@ Configuration file is in flux. For now it is a json looking something like this:
                     "StorageUrl" : ...
                 },
                 "Source" : {
-                    "Provider" : <source provider>
-                    "RepositoryUrl" : ...
-                    "Remote" : ...
-                    "Branch" : ...
-                    "VersionTagRegex" : "^([0-9]+\\.[0-9]+\\.[0-9]+)$"
+                    "Provider" : <source provider>,
+                    "RepositoryUrl" : ...,
+                    "Remote" : ...,
+                    "Branch" : ...,
+                    "VersionTagRegex" : "^([0-9]+\\.[0-9]+\\.[0-9]+)$",
+					"OldestCommitToProcess" : <commit hexsha>,
+					"ExcludeCommitsWithMessageMatchingRegex" : <regex>
                 },
                 "ReleaseNotesWriter" : [{
-                    "Provider" : ...,
+                    "Provider" : <notes writer provider>
                     "PathToSave" : ...
                 }]
             }
@@ -81,7 +83,7 @@ Configuration file is in flux. For now it is a json looking something like this:
 
 where
 
-``notes writer`` is either:
+``notes writer provider`` is either:
 
 - HtmlWriter
 - MarkdownWriter
@@ -96,7 +98,7 @@ where
 - JiraIssues
 - GitHubIssues
 
-It is also possible to specify an array of issue providers, then all of them will be used to retireve information about tickets.
+It is also possible to specify an array of issue providers, then all of them will be used to retrieve information about tickets.
 
 ``source provider`` is currently only:
 

--- a/tests/issuers/JiraIssues_Test.py
+++ b/tests/issuers/JiraIssues_Test.py
@@ -7,16 +7,20 @@ class JiraIssues_Test(unittest.TestCase):
 
   def test_retrieveIssueInfoWhenNoCachedData_ConnectsToTheSource(self):
     requests.packages.urllib3.disable_warnings()
-    ticketResponse = '{ "html_url" : "https://api.github.com/repos/cimpress-mcp/PostalCodes.Net/issues/23", ' \
+    ticketResponse = bytearray('{ "html_url" : "https://api.github.com/repos/cimpress-mcp/PostalCodes.Net/issues/23", ' \
                      '"title" : "Ticket\'s title",' \
                      '"fields" : {' \
                      '"summary" : "Title of TCKT-23",' \
                      '"status" : { "name" : "New", "iconUrl" : "http://site.com/imageUrl.png" },' \
                      '"issuetype" : { "name" : "Task", "iconUrl" : "http://site.com/imageUrl.png" },'\
                      '"priority" : { "name" : "Critical", "iconUrl" : "http://site.com/imageUrl.png" },'\
-                     '"reporter" : { "displayName" : "Test User" }'\
-                     ' }' \
-                     ' }'
+                     '"reporter" : { "displayName" : "', 'utf-8')
+
+    # add an unicode character
+    ticketResponse.append(0xc4)
+    ticketResponse.append(0xb1)
+    for x in bytearray('" } } }', 'utf-8'):
+        ticketResponse.append(x)
 
     config = { "Provider" : "JiraIssues",
                "HtmlUrl" : "https://jira.com/issues",
@@ -24,7 +28,7 @@ class JiraIssues_Test(unittest.TestCase):
                "Url" : "https://jira.com/rest/api/2/issues" }
 
     with requests_mock.mock() as m:
-        m.get('https://jira.com/rest/api/2/issues/TCKT-23', text=ticketResponse)
+        m.get('https://jira.com/rest/api/2/issues/TCKT-23', text=ticketResponse.decode('utf-8'))
         issuer = JiraIssues.JiraIssues(config);
 
         ticketInfo = issuer.getTicketInfo("TCKT-23")

--- a/tests/releaseNotes_Test.py
+++ b/tests/releaseNotes_Test.py
@@ -1,4 +1,5 @@
 import unittest
+from datetime import datetime
 import JustReleaseNotes
 from mock import Mock, MagicMock
 from JustReleaseNotes import releaseNotes
@@ -8,6 +9,8 @@ class ReleaseNote_Test(unittest.TestCase):
     def test_givenSimpleInputPrintVersionBlockGetsCalled(self):
 
         conf = {}
+        conf["Source"] = {}
+        conf["Source"]["OldestCommitToProcess"] = "ef334212ab2323a32323"
         promotedVersions = {}
         ticketProvider = Mock()
         ticketProvider.extractTicketsFromMessage = MagicMock(return_value=["TCKT-1"])
@@ -17,11 +20,16 @@ class ReleaseNote_Test(unittest.TestCase):
         writer = Mock()
         writer.printVersionBlock = MagicMock(return_value="empty")
         repo = Mock()
-        repo.gitCommitsList = ["ef334212ab2323a32323"]
-        repo.versionsByGitHash = { "ef334212ab2323a32323" : "1.0.1.2"}
-        repo.gitHistoryByVersion = {"1.0.1.2" : ["ef334212ab2323a32323"]}
-        repo.gitCommitMessagesByHash = { "ef334212ab2323a32323" : "Something about TCKT-1"}
-
+        repo.gitCommitsList = ["ef334212ab2323a32323",
+                               "as5d4a5sd4a5sd4a5sd4"]
+        repo.versionsByGitHash = {"ef334212ab2323a32323": "1.0.1.2",
+                                  "as5d4a5sd4a5sd4a5sd4": "1.0.1.1"}
+        repo.gitHistoryByVersion = {"1.0.1.2": ["ef334212ab2323a32323"],
+                                    "1.0.1.1": ["as5d4a5sd4a5sd4a5sd4"]}
+        repo.gitCommitMessagesByHash = {"ef334212ab2323a32323": "Something about TCKT-1",
+                                        "as5d4a5sd4a5sd4a5sd4": "Something about TCKT-0"}
+        repo.gitDatesByHash = {"ef334212ab2323a32323" : datetime.strptime("2015-12-12 12:12:12", "%Y-%m-%d %H:%M:%S").toordinal(),
+                               "as5d4a5sd4a5sd4a5sd4" : datetime.strptime("2015-11-11 11:11:11", "%Y-%m-%d %H:%M:%S").toordinal()}
 
         releaseNotes = JustReleaseNotes.releaseNotes.ReleaseNotes(conf, ticketProvider, repo, promotedVersions)
         releaseNotes.generateReleaseNotesByPromotedVersions(writer)


### PR DESCRIPTION
This will allow to limit the history to generate release notes from to a specified commit.
