### PR TITLE
Support Jira labels

### DIFF
--- a/JustReleaseNotes/issuers/JiraIssues.py
+++ b/JustReleaseNotes/issuers/JiraIssues.py
@@ -46,15 +46,17 @@ class JiraIssues(BaseIssues.BaseIssues):
                 "title" : title }
 
         if "fields" in data.keys():
-            title = data["fields"]["summary"]
+            fields = data["fields"]
+            title = fields["summary"]
             ret["title"] = title
             for ticket in self.extractTicketsFromMessage(title):
                 embedded_links[ticket] = "{0}/{1}".format(self.__conf["HtmlUrl"],ticket)
-            ret["state_icon"] = self.__fieldIcon(data["fields"]["status"])
-            ret["issue_type_icon"] = self.__fieldIcon(data["fields"]["issuetype"])
-            ret["priority_icon"] = self.__fieldIcon(data["fields"]["priority"])
+            ret["state_icon"] = self.__fieldIcon(fields["status"])
+            ret["issue_type_icon"] = self.__fieldIcon(fields["issuetype"])
+            ret["priority_icon"] = self.__fieldIcon(fields["priority"])
             ret["embedded_link"] = embedded_links
-            ret["reporter"] = data["fields"]["reporter"]["displayName"]
+            ret["reporter"] = fields["reporter"]["displayName"]
+            ret["tags"] = fields["labels"]
         else:
             return None
 

--- a/tests/issuers/JiraIssues_Test.py
+++ b/tests/issuers/JiraIssues_Test.py
@@ -14,6 +14,7 @@ class JiraIssues_Test(unittest.TestCase):
                      '"status" : { "name" : "New", "iconUrl" : "http://site.com/imageUrl.png" },' \
                      '"issuetype" : { "name" : "Task", "iconUrl" : "http://site.com/imageUrl.png" },'\
                      '"priority" : { "name" : "Critical", "iconUrl" : "http://site.com/imageUrl.png" },'\
+                     '"labels" : [],'\
                      '"reporter" : { "displayName" : "', 'utf-8')
 
     # add an unicode character


### PR DESCRIPTION
The Jira labels are read from the Jira ticket, and then posted into the tags field of the internal representation of a ticket.
