### PR TITLE
Add date to ticket

### DIFF
--- a/JustReleaseNotes/writers/JsonWriter.py
+++ b/JustReleaseNotes/writers/JsonWriter.py
@@ -42,7 +42,7 @@ class JsonWriter(BaseWriter.BaseWriter):
             ticketsInThisVersion.append({"title": "Stability Improvements"})
 
         # the entry contains the version and the tickets, which is serialized into a string
-        entry = {"version": version, "tickets": ticketsInThisVersion}
+        entry = {"version": version, "tickets": ticketsInThisVersion, "date": date}
         self.versionsAlreadyPresent[version] = entry
         block = json.dumps(entry)
         return block

--- a/JustReleaseNotes/writers/JsonWriter.py
+++ b/JustReleaseNotes/writers/JsonWriter.py
@@ -21,7 +21,7 @@ class JsonWriter(BaseWriter.BaseWriter):
 
         # get the content of a specific version if already present
         if version in self.versionsAlreadyPresent.keys():
-            return json.dumps(self.versionsAlreadyPresent[version])
+            return json.dumps(self.versionsAlreadyPresent[version], indent=2, sort_keys=True)
 
         # sort the ticket
         uniqTickets = sorted(set(tickets), reverse=True)
@@ -44,10 +44,11 @@ class JsonWriter(BaseWriter.BaseWriter):
         # the entry contains the version and the tickets, which is serialized into a string
         entry = {"version": version, "tickets": ticketsInThisVersion, "date": date}
         self.versionsAlreadyPresent[version] = entry
-        block = json.dumps(entry)
+        block = json.dumps(entry, indent=2, sort_keys=True)
         return block
 
     # overrides the default behavior of generating the document since we need valid JSON
     def writeDocument(self, content):
         versions = ",".join(content).strip()
-        return "[" + versions + "]"
+        data = json.loads("[" + versions + "]")
+        return json.dumps(data, indent=2, sort_keys=True)

--- a/tests/releaseNotes_Test.py
+++ b/tests/releaseNotes_Test.py
@@ -37,7 +37,7 @@ class ReleaseNote_Test(unittest.TestCase):
 
         releaseNotes = JustReleaseNotes.releaseNotes.ReleaseNotes(conf, ticketProvider, repo, promotedVersions)
         releaseNotes.generateReleaseNotesByPromotedVersions(writer)
-        writer.printVersionBlock.assert_called_once_with({}, "1.0.1.2", "N/A", ["TCKT-1"])
+        writer.printVersionBlock.assert_called_once_with({}, "1.0.1.2", 735944, ["TCKT-1"])
 
     def test_givenUnicodeCharacterInTheInitialContent_DoesntFail(self):
 


### PR DESCRIPTION
When writing a ticket, the date is a useful information, especially when using the JSON formatter. It allows to do special grouping, for example release notes per month or additional re-sorting independently of the version tag.
